### PR TITLE
Updating queue names to align with schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,7 @@ The PAC API is implemented using Cats Effect, to provide an asynchronous runtime
 ### Echo Service
 * Service Identifier (SID): ECHO001
 * Description: The echo service accepts a text message which it returns to the sender
-* Request Queue: request-general
-* Reply Queue: omega-editorial-web-application-instance-1
+* Request Queue: PACS001_request
 * Message Format: plain text
 
 ## Pre-requisites for building and running the project
@@ -47,11 +46,11 @@ docker-compose up -d
 ```
 docker ps -a
 ```
-6. Go to http://localhost:9325/ in a web browser and you should see the message queues configured in `custom.conf`, e.g. `request-general` and `omega-editorial-web-application-instance-1`
+6. Go to http://localhost:9325/ in a web browser and you should see the message queues used by the application and its clients that are configured in `custom.conf`, e.g. `PACS001_request` and `PACE001_reply`
  
 7. To run the unit tests you can use `sbt test`. 
 
-8. To run the Pan-Archival Catalogue Services locally you can use ` sbt run`. Note that the queue names configured in the `application.conf` file used by application must match those in the `custom.conf` file used by ElasticMQ.
+8. To run the Pan-Archival Catalogue Services locally you can use ` sbt run`. Note that the request queue name configured in the `application.conf` file used by application must match the one in the `custom.conf` file used by ElasticMQ.
 
 9. Your message service is now running and ready to respond to requests.
 ## Testing

--- a/custom.conf
+++ b/custom.conf
@@ -2,6 +2,6 @@
 include classpath("application.conf")
 
 queues {
-  request-general { }
-  omega-editorial-web-application-instance-1 { }
+  PACS001_request { }
+  PACE001_reply { }
 }

--- a/src/it/scala/ApiServiceISpec.scala
+++ b/src/it/scala/ApiServiceISpec.scala
@@ -278,7 +278,6 @@ class ApiServiceISpec
       textMessage.setStringProperty(MessageProperties.OMGToken, token)
     }
     messageConfig.replyAddress.foreach { replyAddress =>
-      println(s"The reply address is: $replyAddress")
       textMessage.setStringProperty(MessageProperties.OMGReplyAddress, replyAddress)
     }
     textMessage

--- a/src/it/scala/ApiServiceISpec.scala
+++ b/src/it/scala/ApiServiceISpec.scala
@@ -1,6 +1,8 @@
-import cats.effect.{ IO, Ref }
 import cats.effect.kernel.Resource
 import cats.effect.testing.scalatest.AsyncIOSpec
+import cats.effect.{ IO, Ref }
+import io.circe._
+import io.circe.parser._
 import jms4s.JmsAutoAcknowledgerConsumer.AutoAckAction
 import jms4s.config.QueueName
 import jms4s.jms.JmsMessage
@@ -13,13 +15,11 @@ import org.scalatest.time.{ Seconds, Span }
 import org.scalatest.{ Assertion, BeforeAndAfterAll, BeforeAndAfterEach, FutureOutcome }
 import org.typelevel.log4cats.slf4j.Slf4jFactory
 import org.typelevel.log4cats.{ LoggerFactory, SelfAwareStructuredLogger }
-import uk.gov.nationalarchives.omega.api.conf.ServiceConfig
-import uk.gov.nationalarchives.omega.api.services.ApiService
-import io.circe._
-import io.circe.parser._
 import uk.gov.nationalarchives.omega.api.common.ErrorCode
-import uk.gov.nationalarchives.omega.api.common.ErrorCode.{ BLAN001, INVA002, INVA003, INVA005, INVA006, INVA007, MISS002, MISS003, MISS005, MISS006, MISS007 }
+import uk.gov.nationalarchives.omega.api.common.ErrorCode.{ INVA002, INVA003, INVA005, INVA006, MISS002, MISS003, MISS005, MISS006 }
+import uk.gov.nationalarchives.omega.api.conf.ServiceConfig
 import uk.gov.nationalarchives.omega.api.messages.{ MessageProperties, OutgoingMessageType }
+import uk.gov.nationalarchives.omega.api.services.ApiService
 
 import javax.jms.{ Connection, MessageProducer, Session, TextMessage }
 import scala.concurrent.Await
@@ -44,8 +44,8 @@ class ApiServiceISpec
   implicit override val patienceConfig: PatienceConfig =
     PatienceConfig(timeout = scaled(Span(30, Seconds)), interval = scaled(Span(1, Seconds)))
 
-  private val requestQueueName = "request-general"
-  private val replyQueueName = "omega-editorial-web-application-instance-1"
+  private val requestQueueName = "PACS001_request"
+  private val replyQueueName = "PACE001_reply"
   private val sqsHostName = "localhost"
   private val sqsPort = 9324
 
@@ -56,8 +56,7 @@ class ApiServiceISpec
       maxProducers = 1,
       maxDispatchers = 1,
       maxLocalQueueSize = 1,
-      requestQueue = requestQueueName,
-      replyQueue = replyQueueName
+      requestQueue = requestQueueName
     )
   )
 
@@ -252,54 +251,35 @@ class ApiServiceISpec
       }
     }
 
-    "the OMGReplyAddress" - {
-      "isn't provided" in { f =>
-        val textMessageConfig = generateValidMessageConfig().copy(replyAddress = None)
-
-        sendMessage(f.session, f.producer, textMessageConfig)
-
-        assertReplyMessage(getExpectedJsonErrors(Map(MISS007 -> "Missing OMGReplyAddress"))) *>
-          assertMessageType(OutgoingMessageType.InvalidMessageFormatError.entryName)
-
-      }
-      "isn't valid" in { f =>
-        val textMessageConfig = generateValidMessageConfig().copy(replyAddress = Some("ABCD002."))
-
-        sendMessage(f.session, f.producer, textMessageConfig)
-
-        assertReplyMessage(getExpectedJsonErrors(Map(INVA007 -> "Invalid OMGReplyAddress"))) *>
-          assertMessageType(OutgoingMessageType.InvalidMessageFormatError.entryName)
-
-      }
-    }
   }
 
   private def generateValidMessageConfig(): TextMessageConfig =
     TextMessageConfig(
       contents = "Hello, World",
       messageTypeId = Some("OSGESZZZ100"),
-      applicationId = Some("ABCD002"),
+      applicationId = Some("PACE001"),
       messageFormat = Some("application/json"),
       token = Some("AbCdEf123456"),
-      replyAddress = Some("ABCD002.a")
+      replyAddress = Some("PACE001_reply")
     )
 
   private def asTextMessage(session: Session, messageConfig: TextMessageConfig): TextMessage = {
     val textMessage: TextMessage = session.createTextMessage(messageConfig.contents)
     messageConfig.messageTypeId.foreach { messageTypeId =>
-      textMessage.setStringProperty("OMGMessageTypeID", messageTypeId)
+      textMessage.setStringProperty(MessageProperties.OMGMessageTypeID, messageTypeId)
     }
     messageConfig.applicationId.foreach { applicationId =>
-      textMessage.setStringProperty("OMGApplicationID", applicationId)
+      textMessage.setStringProperty(MessageProperties.OMGApplicationID, applicationId)
     }
     messageConfig.messageFormat.foreach { messageFormat =>
-      textMessage.setStringProperty("OMGMessageFormat", messageFormat)
+      textMessage.setStringProperty(MessageProperties.OMGMessageFormat, messageFormat)
     }
     messageConfig.token.foreach { token =>
-      textMessage.setStringProperty("OMGToken", token)
+      textMessage.setStringProperty(MessageProperties.OMGToken, token)
     }
     messageConfig.replyAddress.foreach { replyAddress =>
-      textMessage.setStringProperty("OMGReplyAddress", replyAddress)
+      println(s"The reply address is: $replyAddress")
+      textMessage.setStringProperty(MessageProperties.OMGReplyAddress, replyAddress)
     }
     textMessage
   }

--- a/src/it/scala/MessageRecoveryISpec.scala
+++ b/src/it/scala/MessageRecoveryISpec.scala
@@ -40,8 +40,8 @@ class MessageRecoveryISpec
   implicit override val patienceConfig: PatienceConfig =
     PatienceConfig(timeout = scaled(Span(60, Seconds)), interval = scaled(Span(5, Millis)))
 
-  private val requestQueueName = "request-general"
-  private val replyQueueName = "omega-editorial-web-application-instance-1"
+  private val requestQueueName = "PACS001_request"
+  private val defaultReplyQueueName = "PACE001_reply"
   private val sqsHostName = "localhost"
   private val sqsPort = 9324
   private val testMessage = "Testing message recovery!"
@@ -84,8 +84,7 @@ class MessageRecoveryISpec
           maxProducers = 1,
           maxDispatchers = 1,
           maxLocalQueueSize = 1,
-          requestQueue = requestQueueName,
-          replyQueue = replyQueueName
+          requestQueue = requestQueueName
         )
       )
     )
@@ -93,7 +92,7 @@ class MessageRecoveryISpec
     val consumerRes = for {
       client <- jmsClient
       consumer <-
-        client.createAutoAcknowledgerConsumer(QueueName(replyQueueName), 1, 100.millis)
+        client.createAutoAcknowledgerConsumer(QueueName(defaultReplyQueueName), 1, 100.millis)
       _ <- Resource.eval(consumer.handle { (jmsMessage, _) =>
              for {
                _ <- readTextMessage(jmsMessage)
@@ -146,11 +145,11 @@ class MessageRecoveryISpec
       "Hello World!",
       Some("OSGESZZZ100"),
       Some(UUID.randomUUID().toString),
-      omgApplicationId = Some("ABCD002"),
+      omgApplicationId = Some("PACE001"),
       Some(System.currentTimeMillis()),
       Some("application/json"),
       Some(UUID.randomUUID().toString),
-      Some("ABCD002.a")
+      Some("PACE001_reply")
     )
 
 }

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -3,5 +3,4 @@ max-consumers = 3
 max-producers = 3
 max-dispatchers = 3
 max-local-queue-size = 100
-request-queue: "request-general"
-reply-queue: "omega-editorial-web-application-instance-1"
+request-queue: "PACS001_request"

--- a/src/main/scala/uk/gov/nationalarchives/omega/api/conf/ServiceConfig.scala
+++ b/src/main/scala/uk/gov/nationalarchives/omega/api/conf/ServiceConfig.scala
@@ -27,6 +27,5 @@ case class ServiceConfig(
   maxProducers: Int,
   maxDispatchers: Int,
   maxLocalQueueSize: Int,
-  requestQueue: String,
-  replyQueue: String
+  requestQueue: String
 )

--- a/src/main/scala/uk/gov/nationalarchives/omega/api/messages/LocalMessage.scala
+++ b/src/main/scala/uk/gov/nationalarchives/omega/api/messages/LocalMessage.scala
@@ -24,6 +24,7 @@ package uk.gov.nationalarchives.omega.api.messages
 import cats.data.ValidatedNec
 import cats.effect.IO
 import cats.syntax.all._
+import jms4s.config.QueueName
 import jms4s.jms.JmsMessage
 import org.typelevel.log4cats.slf4j.Slf4jFactory
 import org.typelevel.log4cats.{ LoggerFactory, SelfAwareStructuredLogger }
@@ -116,7 +117,7 @@ final case class LocalMessage(
             LocalDateTime.ofInstant(Instant.ofEpochMilli(validatedJmsTimestamp), ZoneOffset.UTC),
             validatedOmgMessageFormat,
             validatedOmgToken,
-            validatedOmgReplyAddress
+            QueueName(validatedOmgReplyAddress)
           )
 
       }
@@ -179,7 +180,7 @@ object LocalMessage {
   implicit val logger: SelfAwareStructuredLogger[IO] = LoggerFactory[IO].getLogger
 
   val patternForApplicationId: Regex = "[A-Z]{4}([1-9][0-9][0-9]|0[1-9][0-9]|00[1-9])".r
-  val patternForReplyAddress: Regex = "[A-Z]{4}([1-9][0-9][0-9]|0[1-9][0-9]|00[1-9])(\\.[A-Za-z0-9])+".r
+  val patternForReplyAddress: Regex = "[A-Z]{4}([1-9][0-9][0-9]|0[1-9][0-9]|00[1-9])_([A-Za-z0-9_])+".r
   val patternForServiceId: Regex = "(OS|OD|OE)(LI|GE|UP|CR|RE)(S|F)[A-Z]{3}([1-9][0-9][0-9]|0[1-9][0-9]|00[1-9])".r
 
   val acceptableMimeTypes: Set[String] = Set("application/json")

--- a/src/main/scala/uk/gov/nationalarchives/omega/api/messages/ValidatedLocalMessage.scala
+++ b/src/main/scala/uk/gov/nationalarchives/omega/api/messages/ValidatedLocalMessage.scala
@@ -21,6 +21,7 @@
 
 package uk.gov.nationalarchives.omega.api.messages
 
+import jms4s.config.QueueName
 import uk.gov.nationalarchives.omega.api.common.Version1UUID
 
 import java.time.LocalDateTime
@@ -34,5 +35,5 @@ final case class ValidatedLocalMessage(
   jmsLocalDateTime: LocalDateTime,
   omgMessageFormat: String,
   authToken: String,
-  omgReplyAddress: String
+  omgReplyAddress: QueueName
 )

--- a/src/main/scala/uk/gov/nationalarchives/omega/api/services/ApiService.scala
+++ b/src/main/scala/uk/gov/nationalarchives/omega/api/services/ApiService.scala
@@ -141,7 +141,7 @@ class ApiService(val config: ServiceConfig) extends Stateful {
     stubData: StubDataImpl
   ) =
     new Dispatcher(
-      new LocalProducerImpl(jmsProducer, QueueName(config.replyQueue)),
+      new LocalProducerImpl(jmsProducer),
       localMessageStore,
       new EchoService(),
       new LegalStatusService(stubData)

--- a/src/main/scala/uk/gov/nationalarchives/omega/api/services/Dispatcher.scala
+++ b/src/main/scala/uk/gov/nationalarchives/omega/api/services/Dispatcher.scala
@@ -70,11 +70,13 @@ class Dispatcher(
       _ <- remove(localMessage)
     } yield ()
 
-  private def checkAndReply(localMessage: LocalMessage): IO[Unit] =
+  private def checkAndReply(localMessage: LocalMessage): IO[Unit] = {
+    println(s"LocalMessage.omgReplyAddress = ${localMessage.omgReplyAddress}")
     localMessage.validateOmgApplicationId match {
       case Valid(applicationId) => checkAuthToken(applicationId.validNec, localMessage)
       case Invalid(errors)      => localProducer.sendInvalidApplicationError(localMessage, errors)
     }
+  }
 
   private def checkAuthToken(applicationId: ValidationResult[String], localMessage: LocalMessage): IO[Unit] =
     localMessage.validateOmgToken match {
@@ -147,7 +149,8 @@ class Dispatcher(
   ): IO[Unit] =
     businessResult match {
       case Right(businessResult) =>
-        localProducer.send(businessResult.content, requestMessage)
+        IO.println("Want to send a message..") *>
+          localProducer.send(businessResult.content, requestMessage)
       case Left(serviceError) =>
         localProducer.sendProcessingError(serviceError, requestMessage)
 

--- a/src/main/scala/uk/gov/nationalarchives/omega/api/services/Dispatcher.scala
+++ b/src/main/scala/uk/gov/nationalarchives/omega/api/services/Dispatcher.scala
@@ -70,13 +70,11 @@ class Dispatcher(
       _ <- remove(localMessage)
     } yield ()
 
-  private def checkAndReply(localMessage: LocalMessage): IO[Unit] = {
-    println(s"LocalMessage.omgReplyAddress = ${localMessage.omgReplyAddress}")
+  private def checkAndReply(localMessage: LocalMessage): IO[Unit] =
     localMessage.validateOmgApplicationId match {
       case Valid(applicationId) => checkAuthToken(applicationId.validNec, localMessage)
       case Invalid(errors)      => localProducer.sendInvalidApplicationError(localMessage, errors)
     }
-  }
 
   private def checkAuthToken(applicationId: ValidationResult[String], localMessage: LocalMessage): IO[Unit] =
     localMessage.validateOmgToken match {
@@ -149,8 +147,7 @@ class Dispatcher(
   ): IO[Unit] =
     businessResult match {
       case Right(businessResult) =>
-        IO.println("Want to send a message..") *>
-          localProducer.send(businessResult.content, requestMessage)
+        localProducer.send(businessResult.content, requestMessage)
       case Left(serviceError) =>
         localProducer.sendProcessingError(serviceError, requestMessage)
 

--- a/src/test/scala/uk/gov/nationalarchives/omega/api/services/DispatcherSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/omega/api/services/DispatcherSpec.scala
@@ -166,7 +166,7 @@ class DispatcherSpec
         }
         "is invalid" in {
           assertReplyMessage(
-            generateValidLocalMessageForEchoService().copy(omgReplyAddress = Some("ABCD002.")),
+            generateValidLocalMessageForEchoService().copy(omgReplyAddress = Some("PACE001.reply")),
             getExpectedJsonErrors(Map(INVA007 -> "Invalid OMGReplyAddress"))
           )
         }
@@ -213,11 +213,11 @@ class DispatcherSpec
       "Hello World!",
       Some("OSGESZZZ100"),
       Some(UUID.randomUUID().toString),
-      omgApplicationId = Some("ABCD002"),
+      omgApplicationId = Some("PACE001"),
       Some(System.currentTimeMillis()),
       Some("application/json"),
       Some(UUID.randomUUID().toString),
-      Some("ABCD002.a")
+      Some("PACE001_reply")
     )
 
   /** It is the APIService which is responsible for writing the local message file.

--- a/src/test/scala/uk/gov/nationalarchives/omega/api/services/LocalMessageSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/omega/api/services/LocalMessageSpec.scala
@@ -23,6 +23,7 @@ package uk.gov.nationalarchives.omega.api.services
 
 import cats.data.Validated.Invalid
 import cats.data.{ Chain, Validated }
+import jms4s.config.QueueName
 import org.mockito.scalatest.MockitoSugar
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.must.Matchers
@@ -38,12 +39,12 @@ class LocalMessageSpec extends AnyFreeSpec with Matchers with MockitoSugar {
   private val validPersistentMessageId = Version1UUID.generate()
   private val validCorrelationId = UUID.randomUUID().toString
   private val validMessageText = "At vero eos et accusamus et iusto odio dignissimos"
-  private val validApplicationId = "ABCD002"
+  private val validApplicationId = "PACE001"
   private val validMessageTypeId = "OSGESZZZ100"
   private val validEpochTimeInMilliseconds = System.currentTimeMillis()
   private val validMessageFormat = "application/json"
   private val validAuthToken = "AbCdEf123456"
-  private val validReplyAddress = "ABCD002.a"
+  private val validReplyAddress = "PACE001_reply"
   private val validServiceId = "OSGESZZZ100"
   lazy private val validLocalMessage =
     LocalMessage(
@@ -79,7 +80,7 @@ class LocalMessageSpec extends AnyFreeSpec with Matchers with MockitoSugar {
               LocalDateTime.ofInstant(Instant.ofEpochMilli(validEpochTimeInMilliseconds), ZoneOffset.UTC),
             omgMessageFormat = validMessageFormat,
             authToken = validAuthToken,
-            omgReplyAddress = validReplyAddress
+            omgReplyAddress = QueueName(validReplyAddress)
           )
         )
 
@@ -175,7 +176,7 @@ class LocalMessageSpec extends AnyFreeSpec with Matchers with MockitoSugar {
                   LocalDateTime.ofInstant(Instant.ofEpochMilli(validEpochTimeInMilliseconds), ZoneOffset.UTC),
                 omgMessageFormat = "application/json",
                 authToken = validAuthToken,
-                omgReplyAddress = validReplyAddress
+                omgReplyAddress = QueueName(validReplyAddress)
               )
             )
 
@@ -260,7 +261,7 @@ class LocalMessageSpec extends AnyFreeSpec with Matchers with MockitoSugar {
                   LocalDateTime.ofInstant(Instant.ofEpochMilli(validEpochTimeInMilliseconds), ZoneOffset.UTC),
                 omgMessageFormat = "application/json",
                 authToken = validAuthToken,
-                omgReplyAddress = validReplyAddress
+                omgReplyAddress = QueueName(validReplyAddress)
               )
             )
 
@@ -284,7 +285,7 @@ class LocalMessageSpec extends AnyFreeSpec with Matchers with MockitoSugar {
                   LocalDateTime.ofInstant(Instant.ofEpochMilli(validEpochTimeInMilliseconds), ZoneOffset.UTC),
                 omgMessageFormat = "application/json",
                 authToken = validAuthToken,
-                omgReplyAddress = validReplyAddress
+                omgReplyAddress = QueueName(validReplyAddress)
               )
             )
 

--- a/src/test/scala/uk/gov/nationalarchives/omega/api/services/LocalMessageStoreSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/omega/api/services/LocalMessageStoreSpec.scala
@@ -203,11 +203,11 @@ class LocalMessageStoreSpec
     when(mockJmsMessage.getJMSMessageId).thenReturn(Some(UUID.randomUUID().toString))
     when(mockJmsMessage.getJMSTimestamp).thenReturn(Some(LocalDateTime.now().toEpochSecond(ZoneOffset.UTC)))
     when(mockJmsMessage.getStringProperty(eqTo(MessageProperties.OMGMessageTypeID))).thenReturn(Some("OSGESZZZ100"))
-    when(mockJmsMessage.getStringProperty(eqTo(MessageProperties.OMGApplicationID))).thenReturn(Some("ABCD002"))
+    when(mockJmsMessage.getStringProperty(eqTo(MessageProperties.OMGApplicationID))).thenReturn(Some("PACE001"))
     when(mockJmsMessage.getStringProperty(eqTo(MessageProperties.OMGMessageFormat)))
       .thenReturn(Some("application/json"))
     when(mockJmsMessage.getStringProperty(eqTo(MessageProperties.OMGToken))).thenReturn(Some("application"))
-    when(mockJmsMessage.getStringProperty(eqTo(MessageProperties.OMGReplyAddress))).thenReturn(Some("ABCD002.a"))
+    when(mockJmsMessage.getStringProperty(eqTo(MessageProperties.OMGReplyAddress))).thenReturn(Some("PACE001_reply"))
     mockJmsMessage
   }
 


### PR DESCRIPTION
In this PR I have updated the queue names so that they align with the naming convention provided in the API schema. As part of this I have removed the `reply-queue` from `application.conf` as the reply queue name is expected to be provided by the client application in the message properties. This means that if an reply queue name is not provided we are unable to send an error message to say so. I have therefore removed the tests that expect this to happen.